### PR TITLE
Add API endpoint for participant and team registration in Firestore

### DIFF
--- a/src/app/api/organizer/registration/route.ts
+++ b/src/app/api/organizer/registration/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+import firestore from '@/lib/firebase/firestore';
+
+//Add participant data
+export async function POST(request: NextRequest) {
+    try {
+        const body = await request.json();
+        console.log(body);
+        //check if participant exists
+        if (!body.participants){
+            const { name, matricNo, desasiswa } = body;
+            console.log('Adding participant:', name, matricNo, desasiswa);
+            await firestore.addParticipant({ name, matricNo, desasiswa });
+        } else {
+            const { name, desasiswa, participants } = body;
+            console.log('Adding team:', name, desasiswa, participants);
+            await firestore.addTeam({ name, desasiswa, participants });
+        }
+        return NextResponse.json({ message: 'Participant added' });
+    } catch (error) {
+        console.error('Error adding participant:', error);
+        return new NextResponse('Error adding participant', { status: 500 });
+    }
+}

--- a/src/lib/firebase/firestore.ts
+++ b/src/lib/firebase/firestore.ts
@@ -77,6 +77,28 @@ export class Firestore{
         console.log(matches);
         return matches;
     }
+
+    async addParticipant(data: matchesParticipant){
+        try{
+            const docRef = await addDoc(collection(db, "participants"), data);
+            console.log("Document written with ID: ", docRef.id);
+        } catch(e){
+            console.error("Error adding document: ", e);
+        }
+    }
+
+    async addTeam(data: matchesTeam){
+        try{
+            const docRef = await addDoc(collection(db, "teams"), {
+                teamName: data.name,
+                desasiswa: data.desasiswa,
+                participants: data.participants
+            });
+            console.log("Document written with ID: ", docRef.id);
+        } catch(e){
+            console.error("Error adding document: ", e);
+        }
+    }
 }
 
 const firestore = new Firestore();


### PR DESCRIPTION
This pull request includes significant changes to the registration page for organizers and the backend API to handle registration submissions. The changes focus on simplifying the form structure, improving the user interface, and adding backend support for handling participant and team registrations.

### Frontend Changes:
* [`src/app/(pages)/organizer/registration/page.tsx`](diffhunk://#diff-7ad0fc12ec907080dd704e862e40ca738465141264689407595ab05885ecf721R2-R264): Refactored the registration form to use local state management instead of `react-hook-form` and `zod` for validation. Added new states and functions to manage participants and team details dynamically. Simplified the form layout and updated the UI components.

### Backend Changes:
* [`src/app/api/organizer/registration/route.ts`](diffhunk://#diff-fd311b5c002dd71aafb686adaa9e4d7520df87ee2599314013aa9967bb77a7eaR1-R24): Added a new POST handler to process registration submissions. The handler distinguishes between individual participants and teams, adding them to the Firestore database accordingly.
* [`src/lib/firebase/firestore.ts`](diffhunk://#diff-1a7ac7e96a67cf602f7e86a63f3f3ffec6abbc35a2a712363cee8eab4cbd9ae3R80-R101): Added `addParticipant` and `addTeam` methods to the `Firestore` class to handle adding individual participants and teams to the Firestore database.